### PR TITLE
Add link to LWS repo on github for LWS Vocoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Note this is still WIP and I will update once the training is complete and worki
 1. batching
 2. add regularization such as dropout, layer normalization, etc
 3. improve UI/pipeline for loading data and generating custom setences
-4. replace lws vocoder with sampleRNN/fft-net/wavenet
+4. replace [lws](https://github.com/Jonathan-LeRoux/lws) vocoder with sampleRNN/fft-net/wavenet


### PR DESCRIPTION
Added link on README.md to LWS vocoder (following pip and searching on github) to allow users to easier find LWS vocoder package from the readme page.