### PR TITLE
Added before training section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ A Pytorch implementation of DCTTS ([Efficiently Trainable Text-to-Speech System 
 
 Note this is still WIP and I will update once the training is complete and working well.
 
+## 1. Before Training
+One should have a training and eval directory containing melspectrograms and linear spectrograms using tools such as
+Librosa to compute.
+
+
 # Todo
 1. batching
 2. add regularization such as dropout, layer normalization, etc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Note this is still WIP and I will update once the training is complete and worki
 
 ## 1. Before Training
 One should have a training and eval directory containing melspectrograms and linear spectrograms using tools such as
-Librosa to compute.
+[Librosa](https://librosa.github.io/librosa/) to compute.
 
 
 # Todo


### PR DESCRIPTION
I didn't see any pre-processing scripts for computing the features (melspectrograms), but I did see in the train scripts where you point to two directories for which I'm guessing the features are at. To make the repo more user friendly, added a "Before Training" section for new users in case they want to run the training with their own data and features. Also pointed to using Librosa as a potential pre-processing tool for computing features.
